### PR TITLE
Label Sequence Bottom Prev & Next Arrows

### DIFF
--- a/static/sass/_suclass.scss
+++ b/static/sass/_suclass.scss
@@ -286,6 +286,32 @@ $video-thumb-url: '../themes/suclass/images/stanford-online-video-thumb.png';
     }
 }
 
+// Previous and Next arrow styling changes
+#course-content .sequence-bottom {
+    li {
+        width: 120px;
+
+        a {
+            padding: 14px 10px;
+            text-indent: 0;
+        }
+
+        &.prev {
+            a {
+                padding-left: 40px;
+                background-position: 15px 15px !important;
+            }
+        }
+
+        &.next {
+            a {
+                padding-left: 30px;
+                background-position: 95px 15px !important;
+            }
+        }
+    }
+}
+
 // Shib username page
 section.introduction h1.sr {
     min-height: 100px;


### PR DESCRIPTION
Display "Previous" and "Next" arrows in sequence-bottom nav to make it more obvious that they are for unit navigation.

Resolves LE-286

(Same as lagunita theme [PR#3](https://github.com/Stanford-Online/lagunita-theme/pull/3))

@stvstnfrd & @Stanford-Online/openedx-courseops 
