### PR TITLE
Don't override nav dropdown links

### DIFF
--- a/templates/theme-header.html
+++ b/templates/theme-header.html
@@ -22,9 +22,6 @@
   <img src="${static.url('themes/suclass/images/stanford-S-logo.png')}" height="35" alt="${_('{platform_name}, Courses List').format(platform_name='Stanford Online')}" />
 </%block>
 
-## We don't want extra links inside the navigation dropdown
-<%block name="navigation_dropdown_menu_links" />
-
 ## When unauthenticated, only show the about page link
 <%block name="navigation_global_links">
 


### PR DESCRIPTION
The default links are fine.

(Port of e61214444b81b0cdc906c3366b7da8503da9f126 from lagunita theme)

@stvstnfrd 
