### PR TITLE
Including custom standard copyright

### DIFF
--- a/templates/courseware/courseware.html
+++ b/templates/courseware/courseware.html
@@ -1,0 +1,233 @@
+<%inherit file="/main.html" />
+<%namespace name='static' file='/static_content.html'/>
+<%!
+from django.utils.translation import ugettext as _
+from django.template.defaultfilters import escapejs
+from microsite_configuration import page_title_breadcrumbs
+from django.conf import settings
+from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
+from student.models import UserProfile
+%>
+<%
+  include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and (course.enable_proctored_exams or course.enable_timed_exams)
+%>
+<%def name="course_name()">
+ <% return _("{course_number} Courseware").format(course_number=course.display_number_with_default) %>
+</%def>
+
+<%block name="bodyclass">view-in-course view-courseware courseware ${course.css_class or ''}</%block>
+<%block name="title"><title>
+    % if section_title:
+${page_title_breadcrumbs(section_title, course_name())}
+    % else:
+${page_title_breadcrumbs(course_name())}
+    %endif
+</title></%block>
+
+<%block name="header_extras">
+% for template_name in ["image-modal"]:
+<script type="text/template" id="${template_name}-tpl">
+    <%static:include path="common/templates/${template_name}.underscore" />
+</script>
+% endfor
+
+% if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH'):
+    % for template_name in ["course_search_item", "course_search_results", "search_loading", "search_error"]:
+        <script type="text/template" id="${template_name}-tpl">
+            <%static:include path="search/${template_name}.underscore" />
+        </script>
+    % endfor
+% endif
+
+% if include_special_exams:
+  % for template_name in ["proctored-exam-status"]:
+    <script type="text/template" id="${template_name}-tpl">
+        <%static:include path="courseware/${template_name}.underscore" />
+    </script>
+  % endfor
+% endif
+
+</%block>
+
+<%block name="headextra">
+<%static:css group='style-course-vendor'/>
+<%static:css group='style-course'/>
+## Utility: Notes
+% if is_edxnotes_enabled(course):
+<%static:css group='style-student-notes'/>
+% endif
+
+<%block name="nav_skip">${"#seq_content" if section_title else "#course-content"}</%block>
+
+<%include file="../discussion/_js_head_dependencies.html" />
+  ${fragment.head_html()}
+
+</%block>
+
+<%block name="js_extra">
+  <script type="text/javascript" src="${static.url('js/vendor/jquery.scrollTo-1.4.2-min.js')}"></script>
+  <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js')}"></script>
+
+  ## codemirror
+  <script type="text/javascript" src="${static.url('js/vendor/codemirror-compressed.js')}"></script>
+
+  <%static:js group='courseware'/>
+  <%static:js group='discussion'/>
+  % if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH'):
+    <%static:require_module module_name="js/search/course/course_search_factory" class_name="CourseSearchFactory">
+        var courseId = $('#courseware-search-results').data('courseId');
+        CourseSearchFactory(courseId);
+    </%static:require_module>
+  % endif
+
+  <%include file="../discussion/_js_body_dependencies.html" />
+  % if staff_access:
+    <%include file="xqa_interface.html"/>
+    % if analytics_url:
+        <script type="text/javascript" src="${static.url('js/inline_analytics.js')}"></script> 
+    % endif
+  % endif
+
+  <script type="text/javascript">
+    var $$course_id = "${course.id | escapejs}";
+
+    $(function(){
+        $(".ui-accordion-header a, .ui-accordion-content .subtitle-name").each(function() {
+          var elemText = $(this).text().replace(/^\s+|\s+$/g,''); // Strip leading and trailing whitespace
+          var wordArray = elemText.split(" ");
+          var finalTitle = "";
+          if (wordArray.length > 0) {
+            for (i=0;i<=wordArray.length-1;i++) {
+              finalTitle += wordArray[i];
+              if (i == (wordArray.length-2)) {
+                finalTitle += "&nbsp;";
+              } else if (i == (wordArray.length-1)) {
+                // Do nothing
+              } else {
+                finalTitle += " ";
+              }
+            }
+          }
+          $(this).html(finalTitle);
+        });
+      });
+  </script>
+
+${fragment.foot_html()}
+
+</%block>
+
+% if default_tab:
+  <%include file="/courseware/course_navigation.html" />
+% else:
+  <%include file="/courseware/course_navigation.html" args="active_page='courseware'" />
+% endif
+
+<div class="container">
+  <div class="course-wrapper" role="presentation">
+
+% if disable_accordion is UNDEFINED or not disable_accordion:
+    <div class="course-index">
+      % if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH'):
+        <div id="courseware-search-bar" class="search-bar courseware-search-bar" role="search" aria-label="Course">
+          <form>
+            <label for="course-search-input" class="sr">${_('Course Search')}</label>
+            <div class="search-field-wrapper">
+              <input id="course-search-input" type="text" class="search-field"/>
+              <button type="submit" class="search-button">
+                ${_('search')} <i class="icon fa fa-search" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="cancel-button" aria-label="${_('Clear search')}">
+                <i class="icon fa fa-remove" aria-hidden="true"></i>
+              </button>
+            </div>
+          </form>
+        </div>
+      % endif
+
+      <div class="accordion">
+        <nav class="course-navigation" aria-label="${_('Course')}">
+          % if accordion.strip():
+            ${accordion}
+          % else:
+            <div class="chapter">${_("No content has been added to this course")}</div>
+          % endif
+        </nav>
+      </div>
+
+    </div>
+% endif
+    <section class="course-content" id="course-content" role="main" aria-label="Content">
+        % if getattr(course, 'entrance_exam_enabled') and \
+           getattr(course, 'entrance_exam_minimum_score_pct') and \
+           entrance_exam_current_score is not UNDEFINED:
+            % if not entrance_exam_passed:
+            <p class="sequential-status-message">
+                ${_('To access course materials, you must score {required_score}% or higher on this \
+                exam. Your current score is {current_score}%.').format(
+                    required_score=int(round(course.entrance_exam_minimum_score_pct * 100)),
+                    current_score=int(round(entrance_exam_current_score * 100))
+                )}
+            </p>
+            <script type="text/javascript">
+            $(document).ajaxSuccess(function(event, xhr, settings) {
+                if (settings.url.indexOf("xmodule_handler/problem_check") > -1) {
+                    var data = JSON.parse(xhr.responseText);
+                    if (data.entrance_exam_passed){
+                        location.reload();
+                    }
+                }
+            });
+            </script>
+            % else:
+              <p class="sequential-status-message">
+                ${_('Your score is {current_score}%. You have passed the entrance exam.').format(
+                    current_score=int(round(entrance_exam_current_score * 100))
+                )}
+            </p>
+            % endif
+      % endif
+
+      ${fragment.body_html()}
+    </section>
+    % if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH'):
+      <section id="courseware-search-results" class="search-results courseware-search-results" data-course-id="${course.id}">
+      </section>
+    % endif
+  </div>
+  % if course and user.is_authenticated() and not UserProfile.has_registered(user):
+    <div class="unauth-tos">
+      ${_("By exploring the course, you are agreeing to our {tos_link_start}Terms of Service{link_end} and {privacy_link_start}Privacy Policy{link_end}. Please read them carefully.").format(
+        tos_link_start='<a href="https://lagunita.stanford.edu/tos">',
+        privacy_link_start='<a href="https://lagunita.stanford.edu/tos#privacy">',
+        link_end='</a>'
+      )}
+    </div>
+  % endif
+</div>
+<div class="container-footer">
+  % if settings.FEATURES.get("LICENSING", False):
+    <div class="course-license">
+    % if getattr(course, "license", None):
+      <%include file="../license.html" args="license=course.license" />
+    % else:
+      ## Default course license: All Rights Reserved, if none is explicitly set.
+      <%include file="../license.html" args="license='all-rights-reserved'" />
+    % endif
+    </div>
+  % endif
+</div>
+
+<nav class="nav-utilities ${"has-utility-calculator" if course.show_calculator else ""}" aria-label="${_('Course Utilities')}">
+  ## Utility: Notes
+  % if is_edxnotes_enabled(course):
+    <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
+  % endif
+
+  ## Utility: Calc
+  % if course.show_calculator:
+    <%include file="/calculator/toggle_calculator.html" />
+  % endif
+</nav>
+
+<%include file="../modal/accessible_confirm.html" />

--- a/templates/license.html
+++ b/templates/license.html
@@ -1,0 +1,61 @@
+<%page args="license, button=False, button_size='88x31'"/>
+## keep this synchronized with the contents of cms/templates/js/license-selector.underscore
+<%!
+from django.utils.translation import ugettext as _
+from django.utils.timezone import now
+
+def parse_license(lic):
+    """
+    Returns a two-tuple: license type, and options.
+    """
+    if not lic:
+        return None, {}
+    if ":" not in lic:
+        # no options, so the entire thing is the license type
+        return lic, {}
+
+    ltype, option_str = lic.split(":", 1)
+    options = {}
+    for part in option_str.split():
+        if "=" in part:
+            key, value = part.split("=", 1)
+            options[key] = value
+        else:
+            options[part] = True
+    return ltype, options
+%>
+<% license_type, license_options = parse_license(license) %>
+% if license_type == "all-rights-reserved":
+    © ${now().strftime('%Y')} <span class="license-text">${_("Stanford Medicine")}</span>
+% elif license_type == "creative-commons":
+    <%
+    possible = ["by", "nc", "nd", "sa"]
+    names = {
+       "by": _("Attribution"), "nc": _("Noncommercial"),
+       "nd": _("No Derivatives"), "sa": _("Share Alike")
+    }
+    enabled = [opt for opt in possible
+               if license_options.get(opt) or license_options.get(opt.upper())]
+    version = license_options.get("ver", "4.0")
+    if len(enabled) == 0:
+        enabled = ["zero"]
+        version = license_options.get("ver", "1.0")
+    %>
+    <a rel="license" href="https://creativecommons.org/licenses/${'-'.join(enabled)}/${version}/" target="_blank">
+    % if button:
+        <img src="https://licensebuttons.net/l/${'-'.join(enabled)}/${version}/${button_size}.png"
+             alt="${license}"
+             />
+        </a>
+    % else:
+        ## <span> must come before <i> icon or else spacing gets messed up
+        <span class="sr">${_("Creative Commons licensed content, with terms as follow:")}&nbsp;</span><i aria-hidden="true" class="icon-cc"></i>
+        % for option in enabled:
+            <span class="sr">${names[option]}&nbsp;</span><i aria-hidden="true" class="icon-cc-${option}"></i>
+        % endfor
+        <span class="license-text">${_("Some Rights Reserved")}</span>
+    % endif
+    </a>
+% else:
+    ${license}
+% endif


### PR DESCRIPTION
## [CME2](https://docs.google.com/document/d/1q4M39uZW2M27nyPYAKKIewp4Xj5lffEdhoddVIzdNFE/edit?ts=57d2edbe#bookmark=id.dqrm8x3q1i9j)

### Description

This PR is a theme customization in order to include a standard copyright footer at the bottom of the page under the Unit Navigation.
Basically, we override "courseware" and "license" templates by creating corresponding templates on su-class theme,  but adding requested changes.These new templates dynamically calculate the current year, so there is no need to modify them in the future. 

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.

- [ ] Code review: @stvstnfrd
- [ ] Code review: @felipemontoya

FYI: Tag anyone who might be interested in this PR here

@juancamilom

### Post-review
- [ ] Rebase and squash commits